### PR TITLE
Upgrading IntelliJ from 2022.3.2 to 2022.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2022.3.2 to 2022.3.3
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'Environment Variable Settings Summary'
 # SemVer format -> https://semver.org
-pluginVersion = 3.1.2
+pluginVersion = 3.1.3
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 3.1.2
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2022.3.2,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2022.3.3,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `PreloadingActivity.preload()` in `SdkCleaner`.
 # Exclude `EXPERIMENTAL_API_USAGES` as we use `Application.invokeLaterOnWriteThread()` in `SdkUtils.cleanSDKs()`.
@@ -27,7 +27,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2022.3.2
+platformVersion = 2022.3.3
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2022.3.2 to 2022.3.3

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661465/IntelliJ-IDEA-2022.3.3-223.8836.35-build-Release-Notes

# What's New?
IntelliJ IDEA 2022.3.3 is out! 
<ul> 
 <li>We've resolved the long-standing issue that caused the screen to flicker in full-screen mode on macOS Ventura. [<a href="https://youtrack.jetbrains.com/issue/JBR-4959/macOS-Ventura-Screen-flickering-after-OS-update-when-IDE-is-full-screen">JBR-4959</a>]</li> 
 <li>The IDE no longer displays empty popups on macOS. [<a href="https://youtrack.jetbrains.com/issue/JBR-5258">JBR-5258</a>]</li> 
 <li>The <em>Shelf</em> tab doesn't disappear from the <em>Commit</em> tool window anymore. [<a href="https://youtrack.jetbrains.com/issue/IDEA-305906/IDEA-loses-a-Shelf-tab-in-the-Commit-tool-window-sometimes">IDEA-305906</a>]</li> 
 <li>The <em>Check RegExp</em> action no longer results in a false <em>Bad regular expression pattern</em> alert. [<a href="https://youtrack.jetbrains.com/issue/IDEA-261269/Check-RegExp-says-Bad-regular-expression-pattern-for-valid-literals">IDEA-261269</a>]</li> 
 <li>The IDE correctly saves the set Docker WSL distribution option. [<a href="https://youtrack.jetbrains.com/issue/IDEA-305901/Docker-config-via-WSL-does-not-respect-selected-distribution-and-cant-find-compose-service">IDEA-305901</a>]</li> 
 <li>Attaching folders created outside the IDE via <em>File | Open</em> now works as expected. [<a href="https://youtrack.jetbrains.com/issue/IDEA-311278/">IDEA-311278</a>]</li> 
 <li>It's now possible to check the configuration status of Windows Defender and update it directly from the IDE. To do so, search for <em>Check Windows Defender Status</em> in <em>Find Action</em> (<em>⇧⌘A/Ctrl+Shift+A</em>). [<a href="https://youtrack.jetbrains.com/issue/IDEA-310423">IDEA-310423</a>]</li> 
</ul> For more details, refer to this 
<a href="https://blog.jetbrains.com/idea/2023/03/intellij-idea-2022-3-3/">blog post</a>.
    