### PR TITLE
Upgrading IntelliJ from 2023.1.1 to 2023.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2023.1.1 to 2023.1.2
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 pluginGroup = com.chriscarini.jetbrains
 pluginName = 'SDK Cleaner'
 # SemVer format -> https://semver.org
-pluginVersion = 4.0.1
+pluginVersion = 4.0.2
 
 ### I DO NOT MAKE USE OF SINCE/UNTIL IN THIS PLUGIN.
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
@@ -14,7 +14,7 @@ pluginVersion = 4.0.1
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2023.1.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2023.1.2,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `PreloadingActivity.preload()` in `SdkCleaner`.
 # Exclude `EXPERIMENTAL_API_USAGES` as we use `Application.invokeLaterOnWriteThread()` in `SdkUtils.cleanSDKs()`.
@@ -27,7 +27,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2023.1.1
+platformVersion = 2023.1.2
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2023.1.1 to 2023.1.2

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100661512/IntelliJ-IDEA-2023.1.2-231.9011.34-build-Release-Notes/

# What's New?
IntelliJ IDEA 2023.1.2 is out with the following fixes: 
<ul> 
 <li>The issue causing editor tabs to scroll slowly has been resolved. [<a href="https://youtrack.jetbrains.com/issue/IDEA-318576">IDEA-318576</a>]</li> 
 <li>The IDE no longer erroneously considers projects stored on NFS-mounted drives to be read-only. [<a href="https://youtrack.jetbrains.com/issue/IDEA-315865/Project-on-an-NFS-mounted-drive-is-considered-read-only-in-IDEA-2023.1">IDEA-315865</a>]</li> 
 <li>spring.model.utils.resources no longer causes abnormally high CPU consumption. [<a href="https://youtrack.jetbrains.com/issue/IDEA-316653/Spring-High-CPU-usage-by-IDEA-2023.1-from-spring.model.utils.resources">IDEA-316653</a>]</li> 
 <li>The IDE no longer erroneously reports errors on missing accessors when you use @Embeddable in Spring Data JPA. [<a href="https://youtrack.jetbrains.com/issue/IDEA-240844/JPA-For-property-based-access-both-setter-and-getter-should-be-present-when-using-Embeddable-in-Spring-Data-JPA">IDEA-240844</a>]</li> 
 <li>The list of suggested imports again features all of the corresponding options. [<a href="https://youtrack.jetbrains.com/issue/IDEA-311127/The-suggested-imports-list-is-not-exhaustive">IDEA-311127</a>]</li> 
 <li>The IDE no longer mistakenly reports correct values of the Spring Boot spring.config.import configuration property as errors. [<a href="https://youtrack.jetbrains.com/issue/IDEA-301120/Spring-Boot-configuration-properties-resource-path-values-prefixed-with-aws-secretsmanager-are-reported-as-errors">IDEA-301120</a>]</li> 
 <li>Resyncing Gradle projects no longer fails with the "Missing gradleIdentityPath" error. [<a href="https://youtrack.jetbrains.com/issue/IDEA-317045/Resync-Gradle-projects-throws-Missing-gradleIdentityPath">IDEA-317045</a>]</li> 
 <li>Resizing panes in the <em>Project Structure | Modules</em> dialog now works as expected. [<a href="https://youtrack.jetbrains.com/issue/IDEA-316957/Project-dialog-is-squeezed-because-of-Language-Level-combobox">IDEA-316957</a>]</li> 
</ul> For more details, refer to this 
<a href="https://blog.jetbrains.com/idea/2023/05/intellij-idea-2023-1-2/">blog post</a>.
    