### PR TITLE
Upgrading IntelliJ from 2024.1.5 to 0.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.1.5 to 0.0.0
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,12 +8,12 @@ pluginVersion = 5.0.5
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 241
-pluginUntilBuild = 241.*
+pluginSinceBuild = 242
+pluginUntilBuild = 242.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.1.5,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 0.0,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `PreloadingActivity.preload()` in `SdkCleaner`.
 # Exclude `EXPERIMENTAL_API_USAGES` as we use `Application.invokeLaterOnWriteThread()` in `SdkUtils.cleanSDKs()`.
@@ -26,7 +26,7 @@ platformType = IC
 # and https://www.jetbrains.com/intellij-repository/snapshots/
 # To use/download EAP add '-EAP-SNAPSHOT' to the version, i.e. 'IU-191.6014.8-EAP-SNAPSHOT'
 #        platformVersion = '201.6668.60-EAP-SNAPSHOT'
-platformVersion = 2024.1.5
+platformVersion = 0.0
 platformDownloadSources = true
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.1.5 to 0.0.0

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662085/IntelliJ-IDEA-2024.2.0.1-242.20224.387-build-Release-Notes

# What's New?
IntelliJ IDEA 2024.2.0.1 is out! This update brings important hot-fixes: 
<ul> 
 <li>Install Python Community Edition (PythonCore) plugin when migrating to 2024.2 with Python (PythonId) plugin from 2024.1 or earlier. [<a href="https://youtrack.jetbrains.com/issue/IJPL-158428/Install-Python-Community-Edition-PythonCore-plugin-when-migrating-to-2024.2-with-Python-PythonId-plugin-from-2024.1-or-earlier">IJPL-158428</a>]</li> 
 <li>Trial license is not activated in RD via JetBrains account. [<a href="https://youtrack.jetbrains.com/issue/IJPL-159909">IJPL-159909</a>]</li> 
</ul> For the full details, please refer to 
<a href="https://youtrack.jetbrains.com/articles/IDEA-A-2100662085/IntelliJ-IDEA-2024.2.0.1-242.20224.387-build-Release-Notes">the release notes</a>.
    