### PR TITLE
Upgrading IntelliJ from 2024.3.5 to 2025.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2024.3.5 to 2025.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,16 +8,16 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/jetbrains-sdk-cleaner
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 5.2.8
+pluginVersion = 6.0.0
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 243
-pluginUntilBuild = 243.*
+pluginSinceBuild = 251
+pluginUntilBuild = 251.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2024.3.5,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2025.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `PreloadingActivity.preload()` in `SdkCleaner`.
 # Exclude `EXPERIMENTAL_API_USAGES` as we use `Application.invokeLaterOnWriteThread()` in `SdkUtils.cleanSDKs()`.
@@ -36,7 +36,7 @@ platformType = IC
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2024.3.5
+platformVersion = 2025.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2024.3.5 to 2025.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662421/IntelliJ-IDEA-2025.1-251.23774.435-build-Release-Notes

# What's New?
IntelliJ IDEA 2025.1 is out! Highlights include: 
<ul>
 <li>Java 24 support</li>
 <li>K2 mode by default</li>
 <li>Kotlin notebooks for everyone</li>
 <li>Control over watch evaluators</li>
</ul> Visit our <a href="https://www.jetbrains.com/idea/whatsnew">What's New page</a> to learn about these and other improvements.
    