### PR TITLE
Upgrading IntelliJ from 2026.1 to 2026.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 ### Changed
+- Upgrading IntelliJ from 2026.1 to 2026.1.1
 
 ### Deprecated
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginRepositoryUrl = https://github.com/ChrisCarini/jetbrains-sdk-cleaner
 #   - https://plugins.jetbrains.com/plugins/eap/list
 # Note: You will need to configure the above URL as a custom plugin repository;
 #       see directions: https://www.jetbrains.com/help/idea/managing-plugins.html#repos
-pluginVersion = 7.0.0
+pluginVersion = 7.0.1
 
 ## See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 ## for insight into build numbers and IntelliJ Platform versions.
@@ -17,7 +17,7 @@ pluginUntilBuild = 261.*
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions
-pluginVerifierIdeVersions = 2026.1,LATEST-EAP-SNAPSHOT
+pluginVerifierIdeVersions = 2026.1.1,LATEST-EAP-SNAPSHOT
 # Failure Levels: https://github.com/JetBrains/gradle-intellij-plugin/blob/master/src/main/kotlin/org/jetbrains/intellij/tasks/RunPluginVerifierTask.kt
 # Exclude `DEPRECATED_API_USAGES` as we use `PreloadingActivity.preload()` in `SdkCleaner`.
 # Exclude `EXPERIMENTAL_API_USAGES` as we use `Application.invokeLaterOnWriteThread()` in `SdkUtils.cleanSDKs()`.
@@ -35,7 +35,7 @@ pluginVerifierMutePluginProblems =
 #platformVersion = 2024.1.4                     ## 2024.1.4
 #platformVersion = 242.20224.91-EAP-SNAPSHOT    ## 2024.2 Beta
 #platformVersion = 242.20224.159-EAP-SNAPSHOT   ## 2024.2 RC1
-platformVersion = 2026.1
+platformVersion = 2026.1.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP


### PR DESCRIPTION

# Upgrading IntelliJ from 2026.1 to 2026.1.1

You can find the change log here: https://youtrack.jetbrains.com/articles/IDEA-A-2100662664

# What's New?
<p>IntelliJ IDEA 2026.1.1 is out with the following improvements:</p>
<ul>
 <li>It's once again possible to set up a WSL Python SDK. [<a href="https://youtrack.jetbrains.com/issue/IJPL-240728/Unable-to-add-WSL-Python-SDK">IJPL-240728</a>]</li>
 <li>Emmet in remote development now works as expected. [<a href="https://youtrack.jetbrains.com/issue/IJPL-168255">IJPL-168255</a>]</li>
 <li>Gradle sync no longer fails due to a class cast error involving <code>InternalIdeaModule</code> and <code>org.gradle.tooling.model.ProjectModel</code>. [<a href="https://youtrack.jetbrains.com/issue/IDEA-386409/Gradle-sync-fails-with-InternalIdeaModule-cannot-be-cast-to-class-org.gradle.tooling.model.ProjectModel">IDEA-386409</a>]</li>
 <li>The IDE now correctly connects to the WildFly admin process after server startup, restoring deployment and the <em>Open browser after launch</em> option. [<a href="https://youtrack.jetbrains.com/issue/IDEA-387483">IDEA-387483</a>]</li>
</ul>
<p>Get more details in our <a href="https://blog.jetbrains.com/idea/2026/04/intellij-idea-2026-1-1/">blog post</a>.</p>
    